### PR TITLE
feat(options): add `llm` that defaults to Ollama model qwen2.5-coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,62 @@ it('visits example.com', () => {
 
 ## Options
 
+### llm
+
+LangChain [Runnable](https://js.langchain.com/docs/concepts/runnables/) to invoke. Defaults to a prompt template using the Ollama model `qwen2.5-coder`.
+
+Use a different model:
+
+```ts
+import { Ollama } from '@langchain/ollama';
+import { prompt } from 'cy-ai';
+
+const llm = new Ollama({
+  model: 'codellama',
+  numCtx: 16384,
+});
+
+const chain = prompt.pipe(llm);
+
+cy.ai('prompt', { llm: chain });
+```
+
+Customize the template:
+
+```ts
+import { PromptTemplate } from '@langchain/core/prompts';
+import { Ollama } from '@langchain/ollama';
+
+const llm = new Ollama({
+  model: 'codellama',
+  numCtx: 16384,
+});
+
+const prompt = PromptTemplate.fromTemplate(`
+You are writing an E2E test step with Cypress
+
+Rules:
+1. Return Cypress code without "describe" and "it"
+
+Task: {task}
+
+HTML:
+\`\`\`html
+{html}
+\`\`\`
+`);
+
+const chain = prompt.pipe(llm);
+
+cy.ai('prompt', { llm: chain });
+```
+
+> Don't forget to pull the Ollama model:
+>
+> ```sh
+> ollama pull codellama
+> ```
+
 ### log
 
 Whether to display the command logs. Defaults to `true`:

--- a/cypress/e2e/__generated__/options.cy.ts.json
+++ b/cypress/e2e/__generated__/options.cy.ts.json
@@ -1,5 +1,5 @@
 {
   "options sets options": {
-    "open https://example.com and see heading 'Example Domain'": "cy.visit('https://example.com');\ncy.get('h1').should('contain', 'Example Domain');"
+    "open https://example.com and see heading 'Example Domain'": "cy.visit('https://example.com');\ncy.get('h1').should('have.text', 'Example Domain');"
   }
 }

--- a/cypress/e2e/options.cy.ts
+++ b/cypress/e2e/options.cy.ts
@@ -1,6 +1,27 @@
+import { PromptTemplate } from '@langchain/core/prompts';
+import { Ollama } from '@langchain/ollama';
+
+const llm = new Ollama({
+  model: 'qwen2.5-coder',
+  numCtx: 8192,
+});
+
+const prompt = PromptTemplate.fromTemplate(`
+You are writing an E2E test step with Cypress.
+
+Rules:
+
+1. Return Cypress code without "describe" and "it".
+
+Task: {task}
+`);
+
+const chain = prompt.pipe(llm);
+
 describe('options', () => {
   it('sets options', () => {
     cy.ai("open https://example.com and see heading 'Example Domain'", {
+      llm: chain,
       log: false,
       regenerate: false,
       timeout: 1000 * 60 * 5, // 5 minutes

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,8 +1,9 @@
 /// <reference types="cypress" />
 
+import type { Runnable } from '@langchain/core/runnables';
 import { sanitize } from 'dompurify';
 
-import { generated, llm, options, regex } from './utils';
+import { generated, options, regex } from './utils';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -15,6 +16,13 @@ declare global {
     }
 
     interface Options extends Loggable, Timeoutable {
+      /**
+       * LangChain Runnable to invoke.
+       *
+       * @defaultValue Prompt template using Ollama model `qwen2.5-coder`
+       */
+      llm: Runnable;
+
       /**
        * Whether to regenerate the Cypress step with AI.
        *
@@ -32,6 +40,7 @@ Cypress.Commands.add(name, command);
 function command(
   task: string,
   {
+    llm = options.llm,
     log = options.log,
     regenerate = options.regenerate,
     timeout = options.timeout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
 import './ai';
+
+export { prompt } from './utils/llm';
+export { template } from './utils/template';

--- a/src/utils/generated.ts
+++ b/src/utils/generated.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 
-import { noop } from '.';
+import { noop } from './noop';
 
 const options = { log: false };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,3 @@
 export * as generated from './generated';
-export { chain as llm } from './llm';
-export * from './noop';
 export * as options from './options';
 export * as regex from './regex';

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -8,6 +8,6 @@ const llm = new Ollama({
   numCtx: 16384,
 });
 
-const prompt = PromptTemplate.fromTemplate(template.trim());
+export const prompt = PromptTemplate.fromTemplate(template.trim());
 
 export const chain = prompt.pipe(llm);

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,5 +1,8 @@
 /* eslint-disable prefer-const */
+import { chain } from './llm';
 import { minutes } from './time';
+
+export let llm = chain;
 
 export let log = true;
 


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(options): add `llm` that defaults to Ollama model qwen2.5-coder

## What is the current behavior?

LLM runnable cannot be changed

## What is the new behavior?

LLM runnable can be changed with the `llm` option

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation