### PR TITLE
feat(aiConfig): add command `aiConfig` that sets config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ cy.ai('prompt', { timeout: 1000 * 60 * 5 });
 
 ## cy.aiConfig
 
-Set configuration options for `cy.ai`.
+Set global configuration options for [cy.ai](#cyai).
 
 ### options
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ it('visits example.com', () => {
 > });
 > ```
 
-## Options
+## cy.ai
+
+Use AI to generate Cypress tests given your input.
 
 ### llm
 
@@ -181,6 +183,31 @@ Set timeout to 5 minutes:
 
 ```js
 cy.ai('prompt', { timeout: 1000 * 60 * 5 });
+```
+
+## cy.aiConfig
+
+Set configuration options for `cy.ai`.
+
+### options
+
+Override default options:
+
+```js
+cy.aiConfig({
+  llm: myLLM,
+  log: false,
+  regenerate: true,
+  timeout: 1000 * 60 * 3, // 3 minutes
+});
+```
+
+Set timeout to 5 minutes:
+
+```js
+cy.aiConfig({
+  timeout: 1000 * 60 * 5,
+});
 ```
 
 ## How It Works

--- a/cypress/e2e/aiConfig.cy.ts
+++ b/cypress/e2e/aiConfig.cy.ts
@@ -1,0 +1,34 @@
+import { Ollama } from '@langchain/ollama';
+
+import { prompt } from '../../src';
+import { options } from '../../src/utils';
+import { chain as defaultChain } from '../../src/utils/llm';
+
+const llm = new Ollama({
+  model: 'codellama',
+});
+
+const chain = prompt.pipe(llm);
+
+const TWO_MINUTES = 1000 * 60 * 2;
+
+describe('aiConfig', () => {
+  it('overrides options', () => {
+    expect(options.llm).to.equal(defaultChain);
+    expect(options.log).to.equal(true);
+    expect(options.regenerate).to.equal(false);
+    expect(options.timeout).to.equal(TWO_MINUTES);
+
+    cy.aiConfig({
+      llm: chain,
+      log: false,
+      regenerate: true,
+      timeout: TWO_MINUTES / 2,
+    }).should(() => {
+      expect(options.llm).to.equal(chain);
+      expect(options.log).to.equal(false);
+      expect(options.regenerate).to.equal(true);
+      expect(options.timeout).to.equal(TWO_MINUTES / 2);
+    });
+  });
+});

--- a/cypress/e2e/options.cy.ts
+++ b/cypress/e2e/options.cy.ts
@@ -11,7 +11,7 @@ You are writing an E2E test step with Cypress.
 
 Rules:
 
-1. Return Cypress code without "describe" and "it".
+1. Return JavaScript Cypress code without "describe" and "it".
 
 Task: {task}
 `);

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -12,10 +12,10 @@ declare global {
       /**
        * Run Cypress with AI prompt.
        */
-      ai(task: string, options?: Partial<Options>): Chainable<void>;
+      ai(task: string, options?: Partial<AiOptions>): Chainable<void>;
     }
 
-    interface Options extends Loggable, Timeoutable {
+    interface AiOptions extends Loggable, Timeoutable {
       /**
        * LangChain Runnable to invoke.
        *

--- a/src/aiConfig.ts
+++ b/src/aiConfig.ts
@@ -1,0 +1,40 @@
+/// <reference types="cypress" />
+
+import { options } from './utils';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Set configuration options for `cy.ai`.
+       */
+      aiConfig(options: Partial<AiOptions>): Chainable<void>;
+    }
+  }
+}
+
+Cypress.Commands.add('aiConfig', command);
+
+function command({
+  llm,
+  log,
+  regenerate,
+  timeout,
+}: Partial<Cypress.AiOptions>) {
+  if (typeof llm?.invoke === 'function') {
+    options.llm = llm;
+  }
+
+  if (typeof log === 'boolean') {
+    options.log = log;
+  }
+
+  if (typeof regenerate === 'boolean') {
+    options.regenerate = regenerate;
+  }
+
+  if (timeout && timeout > 0) {
+    options.timeout = timeout;
+  }
+}

--- a/src/aiConfig.ts
+++ b/src/aiConfig.ts
@@ -7,7 +7,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       /**
-       * Set configuration options for `cy.ai`.
+       * Set global configuration options for `cy.ai`.
        */
       aiConfig(options: Partial<AiOptions>): Chainable<void>;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import './ai';
+import './aiConfig';
 
 export { prompt } from './utils/llm';
 export { template } from './utils/template';


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(aiConfig): add command `aiConfig` that sets config options

## What is the current behavior?

No way to globally set config options for `cy.ai`

## What is the new behavior?

Command `cy.aiConfig` to globally set config options for `cy.ai`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation