### PR TITLE
feat(generated): add counter for duplicate tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ When running tests, if the generated Cypress code exists, the command will reuse
 
 To regenerate a step, enable the [regenerate](#regenerate) option or delete the generated code in `cypress/e2e/**/__generated__/*.json`.
 
+> [!WARNING]
+> If you have tests with duplicate or identical titles (`describe` and `it`), it could cause the generated tests to fail.
+
 ## Release
 
 Release is automated with [Release Please](https://github.com/googleapis/release-please).

--- a/cypress/e2e/__generated__/ai.cy.ts.json
+++ b/cypress/e2e/__generated__/ai.cy.ts.json
@@ -1,9 +1,9 @@
 {
   "ai submits form": {
-    "go to example.cypress.io and see \"Kitchen Sink\"": "cy.visit('https://example.cypress.io')\ncy.contains('Kitchen Sink').click()",
-    "click on link \"submit\"": "cy.contains('submit').click()",
-    "find label 'Coupon Code' and type 'HALFOFF'": "cy.contains('Coupon Code').closest('label').next().type('HALFOFF')",
-    "click button 'Submit'": "cy.get('button:contains(\"Submit\")').click()",
-    "assert 'Your form has been submitted!'": "cy.get('p:contains(\"Your form has been submitted!\")').should('be.visible');"
+    "go to example.cypress.io and see \"Kitchen Sink\" 1": "cy.visit('https://example.cypress.io')\ncy.contains('Kitchen Sink').click()",
+    "click on last submit 1": "cy.contains('submit').click()",
+    "find label 'Coupon Code' and type 'HALFOFF' 1": "cy.contains('Coupon Code').closest('label').next().type('HALFOFF')",
+    "click on last submit 2": "cy.get('button:contains(\"Submit\")').click()",
+    "assert 'Your form has been submitted!' 1": "cy.get('p:contains(\"Your form has been submitted!\")').should('be.visible');"
   }
 }

--- a/cypress/e2e/ai.cy.ts
+++ b/cypress/e2e/ai.cy.ts
@@ -1,9 +1,9 @@
 describe('ai', () => {
   it('submits form', () => {
     cy.ai('go to example.cypress.io and see "Kitchen Sink"')
-    cy.ai('click on link "submit"')
+    cy.ai('click on last submit')
     cy.ai("find label 'Coupon Code' and type 'HALFOFF'")
-    cy.ai("click button 'Submit'")
+    cy.ai('click on last submit')
     cy.ai("assert 'Your form has been submitted!'")
   })
 })

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -50,9 +50,9 @@ function command(
     Cypress.log({ displayName: name, message: task })
   }
 
-  generated.read().then((content) => {
+  generated.read(task).then((content) => {
     if (!regenerate) {
-      const code = generated.code(content, task)
+      const code = generated.code(content)
 
       if (code) {
         return eval(code)
@@ -77,7 +77,7 @@ function command(
 
       if (code) {
         eval(code)
-        return generated.save(task, code)
+        return generated.save(code)
       }
 
       throw new Error(response)

--- a/src/utils/noop.ts
+++ b/src/utils/noop.ts
@@ -1,1 +1,0 @@
-export const noop = () => {}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(generated): add counter for duplicate tasks

## What is the current behavior?

If there are duplicate tasks in a test block such as:

```js
it('passes', () => {
  cy.ai('click on button')
  // ...
  cy.ai('click on button')
})
```

The generated JSON will not save the 2nd duplicate task.

## What is the new behavior?

A counter is appended to the task key (similar to [Jest snapshots](https://github.com/jestjs/jest/blob/v29.7.0/packages/jest-snapshot/src/State.ts#L295)) in the generated JSON to ensure it's unique.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation