### PR TITLE
fix(utils): extract codeblock from AIMessage when using chat model

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -3,7 +3,7 @@
 import type { Runnable } from '@langchain/core/runnables'
 import { sanitize } from 'dompurify'
 
-import { generated, options, regex } from './utils'
+import { codeblock, generated, options } from './utils'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -73,7 +73,7 @@ function command(
         })
       }
 
-      const code = response.match(regex.codeblock)?.[2]?.trim()
+      const code = codeblock(response)
 
       if (code) {
         eval(code)

--- a/src/utils/codeblock.ts
+++ b/src/utils/codeblock.ts
@@ -1,0 +1,17 @@
+import { AIMessage } from '@langchain/core/messages'
+
+export function codeblock(response: string | AIMessage) {
+  switch (true) {
+    case typeof response === 'string':
+      return extract(response)
+
+    case response instanceof AIMessage:
+      return extract(response.text)
+  }
+}
+
+const regex = /```(javascript|js)?([\s\S]+?)```/
+
+function extract(text: string) {
+  return text.match(regex)?.[2]?.trim()
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
+export * from './codeblock'
 export * as generated from './generated'
 export * as options from './options'
-export * as regex from './regex'

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,1 +1,0 @@
-export const codeblock = /```(javascript|js)?([\s\S]+?)```/


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(utils): extract codeblock from AIMessage when using chat model

## What is the current behavior?

`ChatOpenAI` and `ChatAnthropic` fails during codeblock extraction due to the Response being an object instead of a string

## What is the new behavior?

Update codeblock extraction logic to get text from `AIMessage`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation